### PR TITLE
Update plugin.yml

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -30,7 +30,7 @@ permissions:
   exampleplugin.command.example:
     description: "Allows the user to run the example command"
     default: true
-    children:
+#   children:
 #     exampleplugin.command.example.test:
 #       description: "Use the test feature in the example command"
 #       default: true


### PR DESCRIPTION
```
19:24:15 [ERROR] Throwing
java.lang.IllegalStateException: 'children' key is of wrong type
        at cn.nukkit.permission.Permission.loadPermission(Permission.java:183) ~[nukkit-1.0-SNAPSHOT.jar:?]
        at cn.nukkit.permission.Permission.loadPermissions(Permission.java:143) ~[nukkit-1.0-SNAPSHOT.jar:?]
        at cn.nukkit.permission.Permission.loadPermissions(Permission.java:134) ~[nukkit-1.0-SNAPSHOT.jar:?]
        at cn.nukkit.plugin.PluginDescription.loadMap(PluginDescription.java:205) ~[nukkit-1.0-SNAPSHOT.jar:?]
        at cn.nukkit.plugin.PluginDescription.<init>(PluginDescription.java:136) ~[nukkit-1.0-SNAPSHOT.jar:?]
        at cn.nukkit.plugin.JavaPluginLoader.getPluginDescription(JavaPluginLoader.java:90) ~[nukkit-1.0-SNAPSHOT.jar:?]
        at cn.nukkit.plugin.PluginManager.loadPlugins(PluginManager.java:165) [nukkit-1.0-SNAPSHOT.jar:?]
        at cn.nukkit.plugin.PluginManager.loadPlugins(PluginManager.java:132) [nukkit-1.0-SNAPSHOT.jar:?]
        at cn.nukkit.plugin.PluginManager.loadPlugins(PluginManager.java:124) [nukkit-1.0-SNAPSHOT.jar:?]
        at cn.nukkit.plugin.PluginManager.loadPlugins(PluginManager.java:120) [nukkit-1.0-SNAPSHOT.jar:?]
        at cn.nukkit.Server.<init>(Server.java:481) [nukkit-1.0-SNAPSHOT.jar:?]
        at cn.nukkit.Nukkit.main(Nukkit.java:112) [nukkit-1.0-SNAPSHOT.jar:?]
```